### PR TITLE
Fix non-admins being unable to spawn dupes containing P2M ent

### DIFF
--- a/lua/entities/gmod_ent_p2m/shared.lua
+++ b/lua/entities/gmod_ent_p2m/shared.lua
@@ -2,7 +2,7 @@ ENT.Base      = "base_anim"
 ENT.PrintName = "P2M Controller"
 ENT.Author    = "shadowscion"
 ENT.Editable  = true
-ENT.Spawnable = false
+ENT.Spawnable = true
 ENT.AdminOnly = false
 ENT.RenderGroup = RENDERGROUP_BOTH
 


### PR DESCRIPTION
This fixes the "Attempted to spawn blacklisted entity '...'" error.