### PR TITLE
Make wrapping and altering behavior easier

### DIFF
--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -15,6 +15,13 @@ util.AddNetworkString("prop2mesh_download")
 
 
 local allow_disable = GetConVar("prop2mesh_disable_allowed")
+function prop2mesh.sendDownload(pl, self, crc)
+	net.Start("prop2mesh_download")
+	net.WriteString(crc)
+	prop2mesh.WriteStream(self.prop2mesh_partlists[crc])
+	net.Send(pl)
+	--print("download", pl)
+end
 
 net.Receive("prop2mesh_download", function(len, pl)
 	if allow_disable:GetBool() and tobool(pl:GetInfoNum("prop2mesh_disable", 0)) then return end
@@ -29,11 +36,7 @@ net.Receive("prop2mesh_download", function(len, pl)
 		return
 	end
 
-	net.Start("prop2mesh_download")
-	net.WriteString(crc)
-	prop2mesh.WriteStream(self.prop2mesh_partlists[crc])
-	net.Send(pl)
-	--print("download", pl)
+	prop2mesh.sendDownload(pl, self, crc)
 end)
 
 net.Receive("prop2mesh_sync", function(len, pl)

--- a/lua/prop2mesh/cl_editor.lua
+++ b/lua/prop2mesh/cl_editor.lua
@@ -801,6 +801,35 @@ local function copyclips(clips)
 	return ret
 end
 
+local copydeeper
+function copydeeper(t, lookup_table)
+	if t == nil then return nil end
+
+	local copy = {}
+	setmetatable(copy, debug.getmetatable(t))
+
+	for i, v in pairs(t) do
+		if not istable(v) then
+			if isvector(v) then
+				copy[i] = Vector(v.x, v.y, v.z)
+			elseif isangle(v) then
+				copy[i] = Angle(v.p, v.y, v.r)
+			else
+				copy[i] = v
+			end
+		else
+			lookup_table = lookup_table or {}
+			lookup_table[t] = copy
+			if lookup_table[v] then
+				copy[i] = lookup_table[v]
+			else
+				copy[i] = copydeeper(v, lookup_table)
+			end
+		end
+	end
+	return copy
+end
+
 local function partcopy(from)
 	local a = { pos = {0, 0, 0}, ang = {0, 0, 0}, scale = {1, 1, 1}, vinvert = 0, vinside = 0, vsmooth = 0, submodels = {}, clips = {} }
 	local b = { pos = {0, 0, 0}, ang = {0, 0, 0}, scale = {1, 1, 1}, vinvert = 0, vinside = 0, vsmooth = 0, submodels = {}, clips = {} }
@@ -821,6 +850,9 @@ local function partcopy(from)
 			elseif k == "clips" then
 				a[k] = copyclips(v)
 				b[k] = copyclips(v)
+			elseif k == "primitive" then
+				a[k] = copydeeper(v)
+				b[k] = copydeeper(v)
 			end
 		end
 	end
@@ -1368,6 +1400,11 @@ function PANEL:OnRemove()
 	end
 	if IsValid(self.Ghost) then
 		self.Ghost:Remove()
+		self.Ghost.GetRenderMesh = nil
+		if self.Ghost.RenderMesh then
+			self.Ghost.RenderMesh:Destroy()
+			self.Ghost.RenderMesh = nil
+		end
 	end
 end
 
@@ -1419,48 +1456,113 @@ local function onPartHover(label)
 
 		self.contree:SetSelectedItem(partnode)
 
-		if partnode.new and (partnode.new.holo or partnode.new.prop) then
-			if self.Ghost.lastSubmodels then
-				for k in pairs(self.Ghost.lastSubmodels) do
-					self.Ghost:SetSubMaterial(k - 1, nil)
+		if partnode.new then
+
+			if partnode.new.holo or partnode.new.prop then
+				self.Ghost.GetRenderMesh = nil
+				if self.Ghost.RenderMesh then
+					self.Ghost.RenderMesh:Destroy()
+					self.Ghost.RenderMesh = nil
 				end
-				self.Ghost.lastSubmodels = nil
-			end
 
-			self.Ghost:SetNoDraw(false)
-			self.Ghost:SetModel(partnode.new.holo or partnode.new.prop)
+				if self.Ghost.lastSubmodels then
+					for k in pairs(self.Ghost.lastSubmodels) do
+						self.Ghost:SetSubMaterial(k - 1, nil)
+					end
+					self.Ghost.lastSubmodels = nil
+				end
 
-			local scale = partnode:GetParentNode().conscale or Vector(1,1,1)
+				self.Ghost:SetNoDraw(false)
+				self.Ghost:SetModel(partnode.new.holo or partnode.new.prop)
+				self.Ghost:SetRenderBounds(self.Ghost:GetModelBounds())
 
-			local pos, ang = LocalToWorld(Vector(unpack(partnode.new.pos))*scale, Angle(unpack(partnode.new.ang)), self.Entity:GetPos(), self.Entity:GetAngles())
+				local scale = partnode:GetParentNode().conscale or Vector(1,1,1)
 
-			self.Ghost:SetParent(self.Entity)
-			self.Ghost:SetPos(pos)
-			self.Ghost:SetAngles(ang)
+				local pos, ang = LocalToWorld(Vector(unpack(partnode.new.pos))*scale, Angle(unpack(partnode.new.ang)), self.Entity:GetPos(), self.Entity:GetAngles())
 
-			if partnode.new.submodels then
-				self.Ghost.lastSubmodels = {}
-				for k, v in pairs(partnode.new.submodels) do
-					if v == 1 then
-						self.Ghost.lastSubmodels[k] = true
-						self.Ghost:SetSubMaterial(k - 1, "Models/effects/vol_light001")
+				self.Ghost:SetParent(self.Entity)
+				self.Ghost:SetPos(pos)
+				self.Ghost:SetAngles(ang)
+
+				if partnode.new.submodels then
+					self.Ghost.lastSubmodels = {}
+					for k, v in pairs(partnode.new.submodels) do
+						if v == 1 then
+							self.Ghost.lastSubmodels[k] = true
+							self.Ghost:SetSubMaterial(k - 1, "Models/effects/vol_light001")
+						end
 					end
 				end
+
+				if partnode.new.clips and #partnode.new.clips > 0 then
+					self.Ghost.clips = partnode.new.clips
+				else
+					self.Ghost.clips = nil
+				end
+
+				if partnode.new.scale then
+					local matrix = Matrix()
+					matrix:SetScale(Vector(unpack(partnode.new.scale))*scale)
+					self.Ghost:EnableMatrix("RenderMultiply", matrix)
+				else
+					self.Ghost:DisableMatrix("RenderMultiply")
+				end
+
+			elseif partnode.new.primitive then
+				self.Ghost.GetRenderMesh = nil
+				if self.Ghost.RenderMesh then
+					self.Ghost.RenderMesh:Destroy()
+					self.Ghost.RenderMesh = nil
+				end
+
+				if self.Ghost.lastSubmodels then
+					for k in pairs(self.Ghost.lastSubmodels) do
+						self.Ghost:SetSubMaterial(k - 1, nil)
+					end
+					self.Ghost.lastSubmodels = nil
+				end
+
+				self.Ghost:SetNoDraw(false)
+				self.Ghost:SetModel("models/Combine_Helicopter/helicopter_bomb01.mdl")
+
+				local _, submeshes = prop2mesh.primitive.construct.get(partnode.new.primitive.construct, partnode.new.primitive, false, false)
+
+				if submeshes and submeshes.tris then
+					self.Ghost:SetRenderBounds(submeshes.mins, submeshes.maxs)
+
+					self.Ghost.RenderMesh = Mesh()
+					self.Ghost.RenderMesh:BuildFromTriangles(submeshes.tris)
+
+					self.Ghost.GetRenderMesh = function(e)
+						return { Mesh = self.Ghost.RenderMesh, Material = wireframe }
+					end
+				end
+
+				local scale = partnode:GetParentNode().conscale or Vector(1,1,1)
+
+				local pos, ang = LocalToWorld(Vector(unpack(partnode.new.pos))*scale, Angle(unpack(partnode.new.ang)), self.Entity:GetPos(), self.Entity:GetAngles())
+
+				self.Ghost:SetParent(self.Entity)
+				self.Ghost:SetPos(pos)
+				self.Ghost:SetAngles(ang)
+
+				if partnode.new.clips and #partnode.new.clips > 0 then
+					self.Ghost.clips = partnode.new.clips
+				else
+					self.Ghost.clips = nil
+				end
+
+				if partnode.new.scale then
+					local matrix = Matrix()
+					matrix:SetScale(Vector(unpack(partnode.new.scale))*scale)
+					self.Ghost:EnableMatrix("RenderMultiply", matrix)
+				else
+					self.Ghost:DisableMatrix("RenderMultiply")
+				end
+			else
+				self.Ghost:SetNoDraw(true)
 			end
 
-			if partnode.new.clips and #partnode.new.clips > 0 then
-				self.Ghost.clips = partnode.new.clips
-			else
-				self.Ghost.clips = nil
-			end
-
-			if partnode.new.scale then
-				local matrix = Matrix()
-				matrix:SetScale(Vector(unpack(partnode.new.scale))*scale)
-				self.Ghost:EnableMatrix("RenderMultiply", matrix)
-			else
-				self.Ghost:DisableMatrix("RenderMultiply")
-			end
 		else
 			self.Ghost:SetNoDraw(true)
 		end

--- a/lua/prop2mesh/cl_editor.lua
+++ b/lua/prop2mesh/cl_editor.lua
@@ -49,10 +49,14 @@ local function HideIcons() return false end
 	uploader
 
 ]]
-local filecache_data = {}
-local filecache_keys = {}
+prop2mesh.filecache_data = {}
+local filecache_data = prop2mesh.filecache_data
 
-local upstreams = {}
+prop2mesh.filecache_keys = {}
+local filecache_keys = prop2mesh.filecache_keys
+
+prop2mesh.upstreams = {}
+local upstreams = prop2mesh.upstreams
 
 net.Receive("prop2mesh_upload_start", function(len)
 	local eid = net.ReadUInt(16)
@@ -71,9 +75,9 @@ end)
 local function upstreamProgress()
 	local max = 0
 	for crc, stream in pairs(upstreams) do
-		local client = next(stream.clients)
-		if client and stream.clients[client] then
-			client = stream.clients[client]
+		local _, client = next(stream.clients)
+
+		if client then
 			if client.finished then
 				upstreams[crc] = nil
 			else

--- a/lua/prop2mesh/sv_editor.lua
+++ b/lua/prop2mesh/sv_editor.lua
@@ -280,6 +280,35 @@ net.Receive("prop2mesh_upload_start", function(len, pl)
 	end
 end)
 
+function prop2mesh.handleUpdate(data, ent, pl, uploadCRC)
+	local updateHandler = ent.prop2mesh_upload_queue
+	local decomp = util.Decompress(data)
+	if uploadCRC == tostring(util.CRC(decomp)) then
+		updateHandler.upload_get[uploadCRC] = updateHandler.upload_ask[uploadCRC]
+		updateHandler.upload_get[uploadCRC].data = decomp
+		updateHandler.upload_ask[uploadCRC] = nil
+	else
+		updateHandler.upload_ask[uploadCRC] = nil
+	end
+
+	if next(updateHandler.upload_ask) then
+		return
+	end
+
+	for uid, upload in pairs(updateHandler.upload_get) do
+		for controllerID in pairs(upload.controllers) do
+			if updateHandler.dataAltered[controllerID] and updateHandler.dataAltered[controllerID] then
+				if not updateHandler.dataAltered[controllerID].custom then
+					updateHandler.dataAltered[controllerID].custom = {}
+				end
+				updateHandler.dataAltered[controllerID].custom[uid] = upload.data
+			end
+		end
+	end
+
+	applyUpdate(ent, pl, updateHandler)
+end
+
 net.Receive("prop2mesh_upload", function(len, pl)
 	local self = Entity(net.ReadUInt(16) or 0)
 	if not canUpload(pl, self) then
@@ -287,353 +316,8 @@ net.Receive("prop2mesh_upload", function(len, pl)
 	end
 
 	local uploadCRC = net.ReadString()
-	local updateHandler = self.prop2mesh_upload_queue
 
 	prop2mesh.ReadStream(pl, function(data)
-		if not canUpload(pl, self) then
-			return
-		end
-
-		local decomp = util.Decompress(data)
-		if uploadCRC == tostring(util.CRC(decomp)) then
-			updateHandler.upload_get[uploadCRC] = updateHandler.upload_ask[uploadCRC]
-			updateHandler.upload_get[uploadCRC].data = decomp
-			updateHandler.upload_ask[uploadCRC] = nil
-		else
-			updateHandler.upload_ask[uploadCRC] = nil
-		end
-
-		if next(updateHandler.upload_ask) then
-			return
-		end
-
-		for uid, upload in pairs(updateHandler.upload_get) do
-			for controllerID in pairs(upload.controllers) do
-				if updateHandler.dataAltered[controllerID] and updateHandler.dataAltered[controllerID] then
-					if not updateHandler.dataAltered[controllerID].custom then
-						updateHandler.dataAltered[controllerID].custom = {}
-					end
-					updateHandler.dataAltered[controllerID].custom[uid] = upload.data
-				end
-			end
-		end
-
-		applyUpdate(self, pl, updateHandler)
+		prop2mesh.handleUpdate(data, self, pl, uploadCRC)
 	end)
 end)
-
-
-/*
-local kvpass = {}
-
-kvpass.vsmooth = function(data, index, val)
-	if isnumber(val) then
-		data[index].vsmooth = (data[index].objd and val) or (val ~= 0 and 1 or nil)
-	end
-end
-
-kvpass.vinvert = function(data, index, val)
-	if isnumber(val) then
-		data[index].vinvert = val ~= 0 and 1 or nil
-	end
-end
-
-kvpass.vinside = function(data, index, val)
-	if isnumber(val) then
-		data[index].vinside = val ~= 0 and 1 or nil
-	end
-end
-
-kvpass.pos = function(data, index, val)
-	if istable(val) and #val == 3 then
-		data[index].pos = Vector(unpack(val))
-	else
-		data[index].pos = Vector()
-	end
-end
-
-kvpass.ang = function(data, index, val)
-	if istable(val) and #val == 3 then
-		data[index].ang = Angle(unpack(val))
-	else
-		data[index].ang = Angle()
-	end
-end
-
-kvpass.scale = function(data, index, val)
-	if istable(val) and #val == 3 and (val[1] ~= 1 or val[2] ~= 1 or val[3] ~= 1) then
-		data[index].scale = Vector(unpack(val))
-	else
-		data[index].scale = nil
-	end
-end
-
-kvpass.submodels = function(data, index, val)
-	if istable(val) then
-		for k, v in pairs(val) do
-			if tobool(v) then val[k] = 1 else val[k] = nil end
-		end
-		data[index].submodels = next(val) and val or nil
-	end
-end
-
--- kvpass.submodelswl = function(data, index, val)
--- 	if isnumber(val) then
--- 		data[index].submodelswl = val ~= 0 and 1 or nil
--- 	end
--- end
-
-
---[[
-
-]]
-local function makeUpdateChanges(self, index, updates, forceSet)
-	local currentData = self:GetControllerData(index)
-	if not currentData then
-		return
-	end
-
-	for pi, pdata in pairs(updates) do
-		if pdata.kill then
-			currentData[pi] = nil
-		else
-			for k, v in pairs(pdata) do
-				local func = kvpass[k]
-				if func then
-					func(currentData, pi, v)
-				end
-			end
-		end
-	end
-
-	local updatedData = { custom = currentData.custom }
-
-	for k, v in pairs(currentData) do
-		if tonumber(k) then
-			updatedData[#updatedData + 1] = v
-		end
-	end
-
-	if forceSet then
-		if next(updatedData) then
-			self:SetControllerData(index, updatedData)
-		else
-			self:ResetControllerData(index)
-		end
-	end
-
-	return updatedData
-end
-
-local function insertUpdateChanges(self, index, partlist, updates)
-	local currentData
-	if updates then
-		currentData = makeUpdateChanges(self, index, updates, false)
-	else
-		currentData = self:GetControllerData(index)
-	end
-	if not currentData then
-		return
-	end
-
-	for i = 1, #currentData do
-		partlist[#partlist + 1] = currentData[i]
-	end
-	if currentData.custom then
-		for crc, data in pairs(currentData.custom) do
-			partlist.custom[crc] = data
-		end
-	end
-end
-
-local function applyUpload(self)
-	local finalData = {}
-
-	for id, upload in pairs(self.prop2mesh_upload_ready) do
-		for index, changes in pairs(upload.controllers) do
-			if not finalData[index] then
-				finalData[index] = { custom = {} }
-			end
-
-			local ok, err = pcall(insertUpdateChanges, self, index, finalData[index], changes.modme)
-			if not ok then
-				print(err)
-			end
-
-			if changes.setme then
-				if changes.setme.uvs then self:SetControllerUVS(index, changes.setme.uvs) end
-				if changes.setme.scale then self:SetControllerScale(index, Vector(unpack(changes.setme.scale))) end
-			end
-
-			finalData[index].custom[id] = upload.data
-
-			for i = 1, #changes.addme do
-				finalData[index][#finalData[index] + 1] = changes.addme[i]
-			end
-		end
-	end
-
-	for index, partlist in pairs(finalData) do
-		if next(partlist) then
-			self:SetControllerData(index, partlist)
-		else
-			self:ResetControllerData(index)
-		end
-	end
-
-	self.prop2mesh_upload_ready = nil
-	self.prop2mesh_upload_queue = nil
-end
-
-
---[[
-
-]]
-net.Receive("prop2mesh_upload_start", function(len, pl)
-	if pl.prop2mesh_antispam then
-		local wait = SysTime() - pl.prop2mesh_antispam
-		if wait < 1 then
-			pl:ChatPrint(string.format("Wait %d more seconds before uploading again", 1 - wait))
-			return
-		end
-	end
-
-	local self = Entity(net.ReadUInt(16) or 0)
-	if not canUpload(pl, self) then
-		return
-	end
-	if self.prop2mesh_upload_queue then
-		return
-	end
-
-	local set, add, mod
-	if net.ReadBool() then set = net.ReadTable() else set = {} end
-	if net.ReadBool() then add = net.ReadTable() else add = {} end
-	if net.ReadBool() then mod = net.ReadTable() else mod = {} end
-
-	if not next(add) then
-		if next(set) or next(mod) then
-			self:SetNetworkedBool("uploading", true)
-
-			for index, updates in pairs(set) do
-				if updates.uvs then
-					self:SetControllerUVS(index, updates.uvs)
-				end
-				if updates.scale then
-					self:SetControllerScale(index, Vector(unpack(updates.scale)))
-				end
-			end
-
-			for index, updates in pairs(mod) do
-				pcall(makeUpdateChanges, self, index, updates, true)
-			end
-
-			self.prop2mesh_upload_queue = true
-			timer.Simple(0, function()
-				self.prop2mesh_upload_queue = nil
-			end)
-		end
-
-		return
-	end
-
-	pl.prop2mesh_antispam = SysTime()
-
-	local uploadQueue = {}
-	local uploadReady = {}
-
-	for index, parts in pairs(add) do
-		if not self.prop2mesh_controllers[index] then
-			goto CONTINUE
-		end
-
-		local data = self.prop2mesh_partlists[self.prop2mesh_controllers[index].crc]
-		if data then
-			data = util.JSONToTable(util.Decompress(data)) -- dangerrrrr
-			data = data.custom
-		end
-
-		for k, part in pairs(parts) do
-			local crc = part.objd
-			if crc then
-				local datagrab = data and data[tonumber(crc)] or nil
-				local utable = datagrab and uploadReady or uploadQueue
-
-				if not utable[crc] then
-					utable[crc] = { controllers = {}, data = datagrab }
-				end
-				if not utable[crc].controllers[index] then
-					utable[crc].controllers[index] = {
-						addme = {},
-						setme = set[index],
-						modme = mod[index],
-					}
-				end
-
-				for key, val in pairs(part) do
-					local func = kvpass[key]
-					if func then
-						func(parts, k, val)
-					end
-				end
-
-				table.insert(utable[crc].controllers[index].addme, part)
-			end
-		end
-
-		::CONTINUE::
-	end
-
-	if next(uploadQueue) then
-		self.prop2mesh_upload_queue = uploadQueue
-		self.prop2mesh_upload_ready = uploadReady
-
-		local keys = table.GetKeys(uploadQueue)
-		net.Start("prop2mesh_upload_start")
-		net.WriteUInt(self:EntIndex(), 16)
-		net.WriteUInt(#keys, 8)
-		for i = 1, #keys do
-			net.WriteString(keys[i])
-		end
-		net.Send(pl)
-
-	elseif next(uploadReady) then
-		self:SetNetworkedBool("uploading", true)
-
-		self.prop2mesh_upload_queue = uploadQueue
-		self.prop2mesh_upload_ready = uploadReady
-
-		applyUpload(self)
-	end
-end)
-
-net.Receive("prop2mesh_upload", function(len, pl)
-	local self = Entity(net.ReadUInt(16) or 0)
-	if not canUpload(pl, self) then
-		return
-	end
-
-	local crc = net.ReadString()
-
-	prop2mesh.ReadStream(pl, function(data)
-		if not canUpload(pl, self) then
-			return
-		end
-
-		local decomp = util.Decompress(data)
-		if crc == tostring(util.CRC(decomp)) then
-			self.prop2mesh_upload_ready[crc] = self.prop2mesh_upload_queue[crc]
-			self.prop2mesh_upload_ready[crc].data = decomp
-			self.prop2mesh_upload_queue[crc] = nil
-		else
-			self.prop2mesh_upload_queue[crc] = nil
-		end
-
-		if next(self.prop2mesh_upload_queue) then
-			return
-		end
-
-		applyUpload(self)
-	end)
-end)
-*/


### PR DESCRIPTION
While working on some backports for [gm_express](https://github.com/CFC-Servers/gm_express), I found a few opportunities to make P2M nicer to hack/manipulate.

Almost exclusively, this PR just pulls out certain network processing/sending code out into their own functions on the `prop2mesh` table so other addons can implement their own code.

This is still a work-in-progress. I'll clean up the code and document my changes better before marking it as ready 👍 