### PR TITLE
Make wrapping functions easier

### DIFF
--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -670,6 +670,36 @@ net.Receive("prop2mesh_sync", function(len)
 end)
 
 prop2mesh.downloads = 0
+function prop2mesh.handleDownload(crc, data)
+	if not crc or not isstring(data) then
+		prop2mesh.downloads = math.max(0, prop2mesh.downloads - 1)
+		return
+	end
+
+	if not recycle[crc] then
+		recycle[crc] = { users = {}, meshes = {} }
+	end
+
+	if crc == util.CRC(data) then
+		recycle[crc].zip = data
+
+		for user in pairs(recycle[crc].users) do
+			if IsValid(user) then
+				for k, info in pairs(user.prop2mesh_controllers) do
+					if info.crc == crc then
+						checkmesh(crc, info.uvs)
+					end
+				end
+			else
+				setuser(user, crc, false)
+			end
+		end
+	else
+		garbage[crc] = SysTime() + 500
+	end
+
+	prop2mesh.downloads = math.max(0, prop2mesh.downloads - 1)
+end
 
 net.Receive("prop2mesh_download", function(len)
 	local crc = net.ReadString()
@@ -680,34 +710,7 @@ net.Receive("prop2mesh_download", function(len)
 	prop2mesh.downloads = prop2mesh.downloads + 1
 
 	prop2mesh.ReadStream(nil, function(data)
-		if not crc or not isstring(data) then
-			prop2mesh.downloads = math.max(0, prop2mesh.downloads - 1)
-			return
-		end
-
-		if not recycle[crc] then
-			recycle[crc] = { users = {}, meshes = {} }
-		end
-
-		if crc == util.CRC(data) then
-			recycle[crc].zip = data
-
-			for user in pairs(recycle[crc].users) do
-				if IsValid(user) then
-					for k, info in pairs(user.prop2mesh_controllers) do
-						if info.crc == crc then
-							checkmesh(crc, info.uvs)
-						end
-					end
-				else
-					setuser(user, crc, false)
-				end
-			end
-		else
-			garbage[crc] = SysTime() + 500
-		end
-
-		prop2mesh.downloads = math.max(0, prop2mesh.downloads - 1)
+		prop2mesh.handleDownload(crc, data)
 	end)
 end)
 

--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -16,10 +16,6 @@ util.AddNetworkString("prop2mesh_sync")
 util.AddNetworkString("prop2mesh_update")
 util.AddNetworkString("prop2mesh_download")
 
-
---[[
-
-]]
 --[[
 local download_wait = 0.1
 local download_time = SysTime()
@@ -116,10 +112,13 @@ end)
 ]]
 
 
---[[
-
-]]
 local allow_disable = GetConVar("prop2mesh_disable_allowed")
+function prop2mesh.sendDownload(pl, self, crc)
+    net.Start("prop2mesh_download")
+    net.WriteString(crc)
+    prop2mesh.WriteStream(self.prop2mesh_partlists[crc])
+    net.Send(pl)
+end
 
 net.Receive("prop2mesh_download", function(len, pl)
 	if allow_disable:GetBool() and tobool(pl:GetInfoNum("prop2mesh_disable", 0)) then return end
@@ -134,11 +133,7 @@ net.Receive("prop2mesh_download", function(len, pl)
 		return
 	end
 
-	net.Start("prop2mesh_download")
-	net.WriteString(crc)
-	prop2mesh.WriteStream(self.prop2mesh_partlists[crc])
-	net.Send(pl)
-	--print("download", pl)
+	prop2mesh.sendDownload(pl, self, crc)
 end)
 
 net.Receive("prop2mesh_sync", function(len, pl)


### PR DESCRIPTION
This is a simpler version of my other PR, https://github.com/shadowscion/Prop2Mesh/pull/43

The goal here is to expose the sending/receiving of P2M Entity data globally. This lets other addons inject new, or modify default networking behavior of Prop2Mesh.

No "new" code was added, I just moved the processing code into new functions on the global `prop2mesh` table.

(Split view recommended during review)