### PR TITLE
File caching

### DIFF
--- a/lua/autorun/prop2mesh.lua
+++ b/lua/autorun/prop2mesh.lua
@@ -37,6 +37,8 @@ end
 
 ]]
 if SERVER then
+	resource.AddWorkshop("2458909924")
+
 	CreateConVar("prop2mesh_disable_allowed", 0, {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "prevents prop2mesh data from networking")
 
 	AddCSLuaFile("prop2mesh/cl_meshlab.lua")

--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -133,8 +133,12 @@ local function checkdownload(self, crc)
 
 	if file.Exists("p2m_cache/" .. crc .. ".dat", "DATA") then
 		local data = file.Read("p2m_cache/" .. crc .. ".dat", "DATA")
-		prop2mesh.handleDownload(crc, data)
-		return true
+		if data and util.CRC(data) == crc then
+			prop2mesh.handleDownload(crc, data)
+			return true
+		end
+
+		file.Delete("p2m_cache/" .. crc .. ".dat")
 	end
 
 	net.Start("prop2mesh_download")


### PR DESCRIPTION
Caches p2m data on the client so clients wont have to redownload data every time they rejoin, this significantly reduces the amount of networking p2m needs to do as people often use the same p2m model anyways. The cached data is stored in the clients datafolder and stored up to a week, each time a mesh is loaded it'll refresh this timer so we don't redownload often used models. The client can configure this cache time with the convar prop2mesh_cache_time.
I've been using this for my 40+ players server for a good while and it makes p2m a lot more manageable.

Also properly sets resource.AddWorkshop so it autodownloads with the git version.