### PR TITLE
Space download requests out, ratelimit downloads

### DIFF
--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -124,6 +124,19 @@ timer.Create("prop2trash", 60, 0, function()
 	end
 end)
 
+local downloadQueue = {}
+timer.Create("prop2mesh_download", 0.1, 0, function()
+	if #downloadQueue == 0 then return end
+
+	local request = table.remove(downloadQueue, 1)
+	if not IsValid(request.ent) then return end
+
+	net.Start("prop2mesh_download")
+	net.WriteEntity(request.ent)
+	net.WriteString(request.crc)
+	net.SendToServer()
+end)
+
 local function checkdownload(self, crc)
 	if recycle[crc] then
 		return true
@@ -141,10 +154,7 @@ local function checkdownload(self, crc)
 		file.Delete("p2m_cache/" .. crc .. ".dat")
 	end
 
-	net.Start("prop2mesh_download")
-	net.WriteEntity(self)
-	net.WriteString(crc)
-	net.SendToServer()
+	table.insert(downloadQueue, {ent = self, crc = crc})
 
 	return false
 end

--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -123,6 +123,11 @@ end
 net.Receive("prop2mesh_download", function(len, pl)
 	if allow_disable:GetBool() and tobool(pl:GetInfoNum("prop2mesh_disable", 0)) then return end
 
+	if pl.prop2mesh_nextdownload and pl.prop2mesh_nextdownload > CurTime() then
+		return
+	end
+	pl.prop2mesh_nextdownload = CurTime() + 0.05
+
 	local self = net.ReadEntity()
 	if not prop2mesh.isValid(self) then
 		return


### PR DESCRIPTION
Currently when a player does a fullupdate, they'll send a request for each p2m in their vision causing possibly 100s of net requests in a single tick.
Having them spaced out clientside has no noticable slowdown for users and allows the server to have a ratelimit to prevent abuse too.