### PR TITLE
Fix CL error

### DIFF
--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -186,7 +186,7 @@ local function checkmesh(crc, uniqueID)
 end
 
 hook.Add("prop2mesh_hook_meshdone", "prop2mesh_meshlab", function(crc, uniqueID, mdata)
-	if not mdata or not crc or not uniqueID then
+	if not mdata or not crc or not uniqueID or not recycle[crc] then
 		return
 	end
 


### PR DESCRIPTION
Fixes:
```
addons/prop2mesh/lua/entities/sent_prop2mesh/cl_init.lua:193 - attempt to index a nil value
1. func - addons/prop2mesh/lua/entities/sent_prop2mesh/cl_init.lua:193
 2. Run - addons/ulib/lua/includes/modules/hook.lua:260
  3. func - addons/prop2mesh/lua/prop2mesh/cl_meshlab.lua:928
   4. <unknown> - addons/ulib/lua/includes/modules/hook.lua:260
```