### PR TITLE
Speed up rate and remove server limit

### DIFF
--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -125,7 +125,7 @@ timer.Create("prop2trash", 60, 0, function()
 end)
 
 local downloadQueue = {}
-timer.Create("prop2mesh_download", 0.1, 0, function()
+timer.Create("prop2mesh_download", 0, 0, function()
 	if #downloadQueue == 0 then return end
 
 	local request = table.remove(downloadQueue, 1)

--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -123,11 +123,6 @@ end
 net.Receive("prop2mesh_download", function(len, pl)
 	if allow_disable:GetBool() and tobool(pl:GetInfoNum("prop2mesh_disable", 0)) then return end
 
-	if pl.prop2mesh_nextdownload and pl.prop2mesh_nextdownload > CurTime() then
-		return
-	end
-	pl.prop2mesh_nextdownload = CurTime() + 0.05
-
 	local self = net.ReadEntity()
 	if not prop2mesh.isValid(self) then
 		return


### PR DESCRIPTION
Speeds the download queue up and removes the server rate limit added in https://github.com/shadowscion/Prop2Mesh/pull/62 as it's not needed at these speeds

1 request per tick should be fine, 0.1s can slow down downloads slightly.