### PR TITLE
Don't throw errors inside meshlab

### DIFF
--- a/lua/prop2mesh/cl_meshlab.lua
+++ b/lua/prop2mesh/cl_meshlab.lua
@@ -39,24 +39,13 @@ local coroutine_yield = coroutine.yield
 local a90 = Angle(0, -90, 0)
 local YIELD_THRESHOLD = 30
 
+local devcvar = GetConVar("developer")
 local cvar = CreateClientConVar("prop2mesh_render_disable_obj", 0, true, false)
 local disable_obj = cvar:GetBool()
 
 cvars.AddChangeCallback("prop2mesh_render_disable_obj", function(cvar, old, new)
     disable_obj = tobool(new)
 end, "swapdrawdisable_obj")
-
-local devcvar = GetConVar("developer")
-
-local function throwerror(withstack, ...)
-	if devcvar:GetBool() then
-		if withstack then
-			ErrorNoHaltWithStack(...)
-		else
-			ErrorNoHalt(...)
-		end
-	end
-end
 
 --[[
 
@@ -876,7 +865,10 @@ local function getVertsFromOBJ(custom, partnext, meshtex, meshbump, vmins, vmaxs
 	local smooth = partnext.vsmooth
 	local parseErr, errChar, errLine = tryParseObj(modelobj, vmesh, vlook, vmins, vmaxs, pos, ang, scale, invert, meshtex)
 	if parseErr then
-		throwerror(false, "Prop2Mesh getVertsFromOBJ failure at line " .. errLine .. ", char " .. errChar .. ": " .. tostring(parseErr) .. "\n")
+		if devcvar:GetBool() then
+			ErrorNoHalt("Prop2Mesh getVertsFromOBJ failure at line " .. errLine .. ", char " .. errChar .. ": " .. tostring(parseErr) .. "\n")
+		end
+
 		coroutine_yield(false)
 	end
 
@@ -1104,7 +1096,10 @@ hook.Add("Think", "prop2mesh_meshlab", function()
 		local ok, err, mdata = coroutine.resume(lab.coro, lab.data, lab.uniqueID)
 
 		if not ok then
-			throwerror(true, "Prop2Mesh Meshlab error: " .. (tostring(err) or "<nil>"))
+			if devcvar:GetBool() then
+				ErrorNoHaltWithStack("Prop2Mesh Meshlab error: " .. (tostring(err) or "<nil>"))
+			end
+
 			meshlabs[key] = nil
 			break
 		end

--- a/lua/prop2mesh/cl_meshlab.lua
+++ b/lua/prop2mesh/cl_meshlab.lua
@@ -61,7 +61,6 @@ end
 --[[
 
 ]]
-
 local function calcbounds(min, max, pos)
 	if pos.x < min.x then min.x = pos.x elseif pos.x > max.x then max.x = pos.x end
 	if pos.y < min.y then min.y = pos.y elseif pos.y > max.y then max.y = pos.y end

--- a/lua/prop2mesh/cl_meshlab.lua
+++ b/lua/prop2mesh/cl_meshlab.lua
@@ -46,10 +46,22 @@ cvars.AddChangeCallback("prop2mesh_render_disable_obj", function(cvar, old, new)
     disable_obj = tobool(new)
 end, "swapdrawdisable_obj")
 
+local devcvar = GetConVar("developer")
+
+local function throwerror(withstack, ...)
+	if devcvar:GetBool() then
+		if withstack then
+			ErrorNoHaltWithStack(...)
+		else
+			ErrorNoHalt(...)
+		end
+	end
+end
 
 --[[
 
 ]]
+
 local function calcbounds(min, max, pos)
 	if pos.x < min.x then min.x = pos.x elseif pos.x > max.x then max.x = pos.x end
 	if pos.y < min.y then min.y = pos.y elseif pos.y > max.y then max.y = pos.y end
@@ -865,7 +877,7 @@ local function getVertsFromOBJ(custom, partnext, meshtex, meshbump, vmins, vmaxs
 	local smooth = partnext.vsmooth
 	local parseErr, errChar, errLine = tryParseObj(modelobj, vmesh, vlook, vmins, vmaxs, pos, ang, scale, invert, meshtex)
 	if parseErr then
-		ErrorNoHalt("Prop2Mesh getVertsFromOBJ failure at line " .. errLine .. ", char " .. errChar .. ": " .. tostring(parseErr) .. "\n")
+		throwerror(false, "Prop2Mesh getVertsFromOBJ failure at line " .. errLine .. ", char " .. errChar .. ": " .. tostring(parseErr) .. "\n")
 		coroutine_yield(false)
 	end
 
@@ -1093,7 +1105,7 @@ hook.Add("Think", "prop2mesh_meshlab", function()
 		local ok, err, mdata = coroutine.resume(lab.coro, lab.data, lab.uniqueID)
 
 		if not ok then
-			ErrorNoHaltWithStack("Prop2Mesh Meshlab error: " .. (tostring(err) or "<nil>"))
+			throwerror(true, "Prop2Mesh Meshlab error: " .. (tostring(err) or "<nil>"))
 			meshlabs[key] = nil
 			break
 		end

--- a/lua/prop2mesh/cl_meshlab.lua
+++ b/lua/prop2mesh/cl_meshlab.lua
@@ -47,6 +47,7 @@ cvars.AddChangeCallback("prop2mesh_render_disable_obj", function(cvar, old, new)
     disable_obj = tobool(new)
 end, "swapdrawdisable_obj")
 
+
 --[[
 
 ]]


### PR DESCRIPTION
These errors are kind of useless if you're not a developer and can confuse players by creating errors out of nowhere
Therefore, i suggest throwing them only if developer is set to 1