### PR TITLE
Add a transparency setting to the "Disabled Rendering" boxes

### DIFF
--- a/lua/autorun/prop2mesh.lua
+++ b/lua/autorun/prop2mesh.lua
@@ -40,6 +40,7 @@ if SERVER then
 	resource.AddWorkshop("2458909924")
 
 	CreateConVar("prop2mesh_disable_allowed", 0, {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "prevents prop2mesh data from networking")
+	CreateConVar("prop2mesh_disabled_transparency_enabled", 1, {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "enables transparency support for disabled prop2mesh entities")
 
 	AddCSLuaFile("prop2mesh/cl_meshlab.lua")
 	AddCSLuaFile("prop2mesh/cl_modelfixer.lua")

--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -285,18 +285,22 @@ local function getComplex(crc, uniqueID)
 	return meshes and meshes.complex
 end
 
-CreateClientConVar("prop2mesh_disabled_transparency", 0.05, true, false, "Disable transparency on prop2mesh entities (forces all to be opaque)", 0, 1)
-
 local vec = Vector()
+
+local serverAllowsTransparency = GetConVar("prop2mesh_disabled_transparency_enabled"):GetBool()
+if serverAllowsTransparency then
+	CreateClientConVar("prop2mesh_disabled_transparency", 0.05, true, false, "Disable transparency on prop2mesh entities (forces all to be opaque)", 0, 1)
+
+	cvars.AddChangeCallback("prop2mesh_disabled_transparency", function(cvar, old, new)
+		debugwhite:SetFloat("$alpha", math.Clamp(tonumber(new) or 0, 0, 1))
+	end, "p2mdebugwhitealpha")
+end
+
 local debugwhite = CreateMaterial("p2mdebugwhite", "UnlitGeneric", {
 	["$basetexture"] = "color/white",
 	["$vertexcolor"] = 1,
-	["$alpha"] = GetConVar("prop2mesh_disabled_transparency"):GetFloat()
+	["$alpha"] = serverAllowsTransparency and GetConVar("prop2mesh_disabled_transparency"):GetFloat() or 1
 })
-
-cvars.AddChangeCallback("prop2mesh_disabled_transparency", function(cvar, old, new)
-	debugwhite:SetFloat("$alpha", math.Clamp(tonumber(new) or 0, 0, 1))
-end, "p2mdebugwhitealpha")
 
 local renderOverride
 do

--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -287,20 +287,21 @@ end
 
 local vec = Vector()
 
-local serverAllowsTransparency = GetConVar("prop2mesh_disabled_transparency_enabled"):GetBool()
-if serverAllowsTransparency then
-	CreateClientConVar("prop2mesh_disabled_transparency", 0.05, true, false, "Disable transparency on prop2mesh entities (forces all to be opaque)", 0, 1)
+CreateClientConVar("prop2mesh_disabled_transparency", 0.05, true, false, "Disable transparency on prop2mesh entities (forces all to be opaque)", 0, 1)
 
-	cvars.AddChangeCallback("prop2mesh_disabled_transparency", function(cvar, old, new)
-		debugwhite:SetFloat("$alpha", math.Clamp(tonumber(new) or 0, 0, 1))
-	end, "p2mdebugwhitealpha")
-end
+local serverAllowsTransparency = GetConVar("prop2mesh_disabled_transparency_enabled"):GetBool()
 
 local debugwhite = CreateMaterial("p2mdebugwhite", "UnlitGeneric", {
 	["$basetexture"] = "color/white",
 	["$vertexcolor"] = 1,
 	["$alpha"] = serverAllowsTransparency and GetConVar("prop2mesh_disabled_transparency"):GetFloat() or 1
 })
+
+if serverAllowsTransparency then
+	cvars.AddChangeCallback("prop2mesh_disabled_transparency", function(cvar, old, new)
+		debugwhite:SetFloat("$alpha", math.Clamp(tonumber(new) or 0, 0, 1))
+	end, "p2mdebugwhitealpha")
+end
 
 local renderOverride
 do

--- a/lua/entities/sent_prop2mesh/cl_init.lua
+++ b/lua/entities/sent_prop2mesh/cl_init.lua
@@ -285,11 +285,18 @@ local function getComplex(crc, uniqueID)
 	return meshes and meshes.complex
 end
 
+CreateClientConVar("prop2mesh_disabled_transparency", 0.05, true, false, "Disable transparency on prop2mesh entities (forces all to be opaque)", 0, 1)
+
 local vec = Vector()
 local debugwhite = CreateMaterial("p2mdebugwhite", "UnlitGeneric", {
 	["$basetexture"] = "color/white",
-	["$vertexcolor"] = 1
+	["$vertexcolor"] = 1,
+	["$alpha"] = GetConVar("prop2mesh_disabled_transparency"):GetFloat()
 })
+
+cvars.AddChangeCallback("prop2mesh_disabled_transparency", function(cvar, old, new)
+	debugwhite:SetFloat("$alpha", math.Clamp(tonumber(new) or 0, 0, 1))
+end, "p2mdebugwhitealpha")
 
 local renderOverride
 do

--- a/lua/weapons/gmod_tool/stools/prop2mesh.lua
+++ b/lua/weapons/gmod_tool/stools/prop2mesh.lua
@@ -958,6 +958,8 @@ local function BuildPanel_AddonSettings(self)
 		cbox.Label:SetTextColor(value and Color(255, 0, 0) or nil)
 	end
 
+	local slider = pnl:NumSlider("Transparency:", "prop2mesh_disabled_transparency", 0, 1, 2)
+
 	local cbox = pnl:CheckBox("Disable everything", "prop2mesh_disable")
 	cbox:SetTooltip("Note: unless you rejoin, this will not apply to already generated meshes")
 	cbox.OnChange = function(_, value)

--- a/lua/weapons/gmod_tool/stools/prop2mesh.lua
+++ b/lua/weapons/gmod_tool/stools/prop2mesh.lua
@@ -960,6 +960,11 @@ local function BuildPanel_AddonSettings(self)
 
 	local slider = pnl:NumSlider("Transparency:", "prop2mesh_disabled_transparency", 0, 1, 2)
 
+	local serverAllowsTransparency = GetConVar("prop2mesh_disabled_transparency_enabled"):GetBool()
+	if not serverAllowsTransparency then
+		slider:SetEnabled( false )
+	end
+
 	local cbox = pnl:CheckBox("Disable everything", "prop2mesh_disable")
 	cbox:SetTooltip("Note: unless you rejoin, this will not apply to already generated meshes")
 	cbox.OnChange = function(_, value)


### PR DESCRIPTION
This adds a settings for users to control the transparency of the boxes that are visible when rendering is disabled.
The default is set to `0.05` and can be modified either through the client convar `prop2mesh_disabled_transparency` or through a slider below the checkbox for disabling rendering:
<img width="260" height="175" alt="image" src="https://github.com/user-attachments/assets/1cb29008-df9f-4e7c-ba6c-7553fcd70ca2" />

There is also a server managed convar to allow or disallow the use of transparency on the server named `serverAllowsTransparency` which allows it by default.
Useful to prevent players from seeing internal components on things like ACF servers.

>[!NOTE]
>Changing this setting requires a map change or server restart to take effect.

---

Here is a comparision of how that looks in game.

Before:
<img width="555" height="633" alt="image" src="https://github.com/user-attachments/assets/134e14a4-fed4-413d-84f3-2fddfc1ebba2" />

After:
<img width="555" height="633" alt="image" src="https://github.com/user-attachments/assets/5fbf3237-46ce-4d3c-86b0-ba5c58896fa9" />
