### PR TITLE
Add controller merging

### DIFF
--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -381,6 +381,58 @@ function ENT:MergeControllers(fromIndex, intoIndex)
 	return true
 end
 
+function ENT:MergeEntities(other)
+	-- the target must be a different, valid prop2mesh controller entity
+	if not prop2mesh.isValid(other) or other == self then return false end
+	if not next(self.prop2mesh_controllers) then return false end
+
+	local frompos, fromang = self:GetPos(), self:GetAngles()
+	local intopos, intoang = other:GetPos(), other:GetAngles()
+
+	for index, info in ipairs(self.prop2mesh_controllers) do
+		-- add a matching controller on the target and copy this one's appearance
+		other:AddController()
+		local newIndex = #other.prop2mesh_controllers
+
+		other:SetControllerCol(newIndex, info.col)
+		other:SetControllerMat(newIndex, info.mat)
+		other:SetControllerUVS(newIndex, info.uvs)
+		other:SetControllerBump(newIndex, info.bump)
+		other:SetControllerScale(newIndex, info.scale)
+
+		if info.clips then
+			for _, clip in ipairs(info.clips) do
+				other:AddControllerClip(newIndex, unpack(clip))
+			end
+		end
+
+		if info.name then
+			other:SetControllerName(newIndex, info.name)
+		end
+
+		-- transform mesh parts into new controller's frame.
+		-- positions are multiplied by scale, so need to undo that first.
+		local partlist = self:GetControllerData(index)
+		if partlist then
+			local sx, sy, sz = info.scale.x, info.scale.y, info.scale.z
+			for _, part in ipairs(partlist) do
+				local pos = Vector(part.pos.x * sx, part.pos.y * sy, part.pos.z * sz)
+				local wpos, wang = LocalToWorld(pos, part.ang, frompos, fromang)
+				local lpos, lang = WorldToLocal(wpos, wang, intopos, intoang)
+				part.pos = Vector(sx ~= 0 and lpos.x / sx or 0, sy ~= 0 and lpos.y / sy or 0, sz ~= 0 and lpos.z / sz or 0)
+				part.ang = lang
+			end
+			other:SetControllerData(newIndex, partlist)
+		end
+	end
+
+	other.prop2mesh_sync = true
+
+	self:Remove()
+
+	return true
+end
+
 function ENT:SendControllers(syncwith)
 	net.Start("prop2mesh_sync")
 

--- a/lua/entities/sent_prop2mesh/init.lua
+++ b/lua/entities/sent_prop2mesh/init.lua
@@ -334,6 +334,53 @@ function ENT:RemoveController(index)
 	return true
 end
 
+function ENT:MergeControllers(fromIndex, intoIndex)
+	fromIndex = tonumber(fromIndex)
+	intoIndex = tonumber(intoIndex)
+
+	-- both controllers must exist, and merging into itself makes no sense
+	local fromInfo = fromIndex and self.prop2mesh_controllers[fromIndex]
+	local intoInfo = intoIndex and self.prop2mesh_controllers[intoIndex]
+	if not fromInfo or not intoInfo or fromIndex == intoIndex then
+		return false
+	end
+
+	-- decompress both partlists so their part arrays can be concatenated
+	local fromData = self:GetControllerData(fromIndex) or {}
+	local intoData = self:GetControllerData(intoIndex) or {}
+
+	-- start from the target's parts/custom meshes, keeping its material/color/etc.
+	local merged = { custom = {} }
+	for i = 1, #intoData do
+		merged[#merged + 1] = intoData[i]
+	end
+	if intoData.custom then
+		for crc, data in pairs(intoData.custom) do
+			merged.custom[crc] = data
+		end
+	end
+
+	-- append the source's parts/custom meshes on top
+	for i = 1, #fromData do
+		merged[#merged + 1] = fromData[i]
+	end
+	if fromData.custom then
+		for crc, data in pairs(fromData.custom) do
+			merged.custom[crc] = data
+		end
+	end
+
+	-- write the combined partlist to the target, then delete the source controller
+	if #merged > 0 then
+		self:SetControllerData(intoIndex, merged)
+	else
+		self:ResetControllerData(intoIndex)
+	end
+	self:RemoveController(fromIndex)
+
+	return true
+end
+
 function ENT:SendControllers(syncwith)
 	net.Start("prop2mesh_sync")
 

--- a/lua/entities/sent_prop2mesh/shared.lua
+++ b/lua/entities/sent_prop2mesh/shared.lua
@@ -150,3 +150,71 @@ properties.Add("prop2mesh", {
 		option:SetText("Export all E2M as .obj")
 	end,
 })
+
+
+-- Merge a prop2mesh entity into another: move all controllers over, then remove the source
+properties.Add("prop2mesh_merge", {
+	MenuLabel     = "Merge prop2mesh into",
+	MenuIcon      = "icon16/chart_organisation.png",
+	PrependSpacer = false,
+	Order         = 3002,
+
+	Filter = function(self, ent, pl)
+		if not IsValid(ent) then return false end
+		if not prop2mesh.isValid(ent) then return false end
+		if not gamemode.Call("CanProperty", pl, "prop2mesh", ent) then return false end
+		return next(ent.prop2mesh_controllers) ~= nil
+	end,
+
+	GetTargets = function(self, ent, pl)
+		local targets = {}
+		for _, other in ipairs(ents.FindByClass("sent_prop2mesh")) do
+			if other ~= ent and self:Filter(other, pl) then
+				targets[#targets + 1] = other
+			end
+		end
+		return targets
+	end,
+
+	Action = function(self, ent) end,
+
+	MenuOpen = function(self, option, ent, tr)
+		local submenu = option:AddSubMenu()
+		local targets = self:GetTargets(ent, LocalPlayer())
+
+		if not next(targets) then
+			submenu:AddOption("(no other prop2mesh entities)", function() end):SetIcon("icon16/cross.png")
+			return
+		end
+
+		for _, other in ipairs(targets) do
+			local count = #other.prop2mesh_controllers
+			local label = string.format("Entity [%d] (%d controller%s)", other:EntIndex(), count, count == 1 and "" or "s")
+
+			submenu:AddOption(label, function()
+				Derma_Query(
+					"All controllers will be moved onto the target entity and this entity will be removed.\nIf your controllers are misaligned and have non uniform scaling, this may not work well.",
+					string.format("Merge this prop2mesh into Entity [%d]?", other:EntIndex()),
+					"Yes", function()
+						self:MsgStart()
+						net.WriteEntity(ent)
+						net.WriteEntity(other)
+						self:MsgEnd()
+					end,
+					"No", function() end
+				)
+			end):SetIcon("icon16/bullet_black.png")
+		end
+	end,
+
+	Receive = function(self, len, pl) -- SERVER
+		local from = net.ReadEntity()
+		local into = net.ReadEntity()
+
+		if from == into then return end
+		if not self:Filter(from, pl) then return end
+		if not self:Filter(into, pl) then return end
+
+		from:MergeEntities(into)
+	end,
+})

--- a/lua/entities/sent_prop2mesh/shared.lua
+++ b/lua/entities/sent_prop2mesh/shared.lua
@@ -163,6 +163,7 @@ properties.Add("prop2mesh_merge", {
 		if not IsValid(ent) then return false end
 		if not prop2mesh.isValid(ent) then return false end
 		if not gamemode.Call("CanProperty", pl, "prop2mesh", ent) then return false end
+		if self:CPPIGetOwner() ~= pl then return false end
 		return next(ent.prop2mesh_controllers) ~= nil
 	end,
 

--- a/lua/prop2mesh/cl_editor.lua
+++ b/lua/prop2mesh/cl_editor.lua
@@ -1122,6 +1122,41 @@ local function conmenu(frame, conroot)
 			end
 		end ):SetIcon( "icon16/bullet_black.png" )
 
+		local mergesub, mergeopt = menu:AddSubMenu("merge into")
+		mergeopt:SetIcon("icon16/chart_organisation.png")
+
+		-- Build a list of all other controllers to merge into, excluding the current one
+		for k, v in pairs(frame.conroots) do
+			if k ~= conroot.num then
+				local target = v.conroot
+				local label = target.info.name or string.format("controller %d", target.num)
+
+				mergesub:AddOption(label, function()
+					local pnl = Derma_Query(string.format("This will IGNORE any unconfirmed changes to all controllers, and match [%s]'s material, color, and other appearance settings.", label), string.format("Merge controller [%s] into [%s]?", conroot.info.name or conroot.num, label), "Yes", function()
+						-- discard unconfirmed edits so indices aren't left stale once the merge shifts controllers
+						for pk, pv in pairs(frame.updates) do pv.add, pv.mod, pv.set = {}, {}, {} end
+
+						updates.set.mergeinto = target.num
+
+						frame.btnConfirm:DoClick()
+					end, "No", function() end)
+
+					pnl.lblTitle:SetFont(editor_font)
+					pnl.lblTitle:SetTextColor(color_white)
+
+					local time = SysTime()
+
+					pnl.Paint = function(_, w, h)
+						Derma_DrawBackgroundBlur(pnl, time)
+						surface.SetDrawColor(theme.colorMain)
+						surface.DrawRect(0, 0, w, h)
+						surface.SetDrawColor(0, 0, 0)
+						surface.DrawOutlinedRect(0, 0, w, h)
+					end
+				end):SetIcon("icon16/bullet_black.png")
+			end
+		end
+
 		menu:AddOption("set controller name", function()
 			local pnl = Derma_StringRequest(string.format("Set name of controller [%s]?", conroot.info.name or conroot.num), "This will CONFIRM any other changes to all controllers.", conroot.info.name or "", function(text)
 				if text == "" or conroot.info.name == text then

--- a/lua/prop2mesh/sv_editor.lua
+++ b/lua/prop2mesh/sv_editor.lua
@@ -54,6 +54,9 @@ local safeControllerValues = {
 	remove = function(val)
 		return tobool(val)
 	end,
+	mergeinto = function(val)
+		return isnumber(val) and math.floor(val) or nil
+	end,
 }
 
 local safePartValues = {
@@ -118,6 +121,8 @@ local function applyUpdate(self, pl, updateHandler)
 		for controllerID, edits in pairs(updateHandler.controllerAltered) do
 			if edits.remove then
 				self:RemoveController(controllerID)
+			elseif edits.mergeinto then
+				self:MergeControllers(controllerID, edits.mergeinto)
 			else
 				if edits.uvs then
 					self:SetControllerUVS(controllerID, edits.uvs)


### PR DESCRIPTION
Adds a button to merge controllers within the same p2m entity. Accessible by right clicking any controller and selecting the "merge into" button.

Additionally adds an option to merge sent_prop2mesh entities. Similar deal.