### PR TITLE
Fix lua error

### DIFF
--- a/lua/weapons/gmod_tool/stools/prop2mesh.lua
+++ b/lua/weapons/gmod_tool/stools/prop2mesh.lua
@@ -283,11 +283,9 @@ if SERVER then
 	end
 
 	function TOOL:Deploy()
-		timer.Simple(0.1, function()
-			if IsValid(self.p2m.ent) then
-				self:SetStage(1)
-			end
-		end)
+		if IsValid(self.p2m.ent) then
+			self:SetStage(1)
+		end
 	end
 
 	function TOOL:SetDataByIndex(add)


### PR DESCRIPTION
Should fix:
```
- gamemodes/sandbox/entities/weapons/gmod_tool/object.lua:11: Tried to use a NULL entity!
1. SetNWInt - [C]:-1
 2. SetStage - gamemodes/sandbox/entities/weapons/gmod_tool/object.lua:11
  3. <unknown> - addons/prop2mesh/lua/weapons/gmod_tool/stools/prop2mesh.lua:288
```
Is there any reason why this is done in 0.1 timer?