### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/sent_prop2mesh/shared.lua
+++ b/lua/entities/sent_prop2mesh/shared.lua
@@ -163,7 +163,7 @@ properties.Add("prop2mesh_merge", {
 		if not IsValid(ent) then return false end
 		if not prop2mesh.isValid(ent) then return false end
 		if not gamemode.Call("CanProperty", pl, "prop2mesh", ent) then return false end
-		if self:CPPIGetOwner() ~= pl then return false end
+		if ent:CPPIGetOwner() ~= pl then return false end
 		return next(ent.prop2mesh_controllers) ~= nil
 	end,
 


### PR DESCRIPTION
Fixes:
```
- addons/prop2mesh/lua/entities/sent_prop2mesh/shared.lua:166: attempt to call method 'CPPIGetOwner' (a nil value)
1. Filter - addons/prop2mesh/lua/entities/sent_prop2mesh/shared.lua:166
 2. OpenEntityMenu - lua/includes/modules/properties.lua:93
  3. OnScreenClick - lua/includes/modules/properties.lua:110
   4. <unknown> - lua/includes/modules/properties.lua:216
    5. Run - addons/hook-library/lua/includes/modules/hook.lua:348
     6. <unknown> - gamemodes/sandbox/gamemode/spawnmenu/contextmenu.lua:157
```